### PR TITLE
feature/parallelise-postcode-searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .env
 .idea/
 data/task/payloads.yml
-data/task/asda-check-delivery-slots.yml
 data/cache/*
 data/taskstate/*
 vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .env
 .idea/
 data/task/payloads.yml
-data/tasks/asda-check-delivery-slots.yml
+data/task/asda-check-delivery-slots.yml
 data/cache/*
-data/jobstate/*
+data/taskstate/*
 vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .idea/
+data/task/payloads.yml
 data/tasks/asda-check-delivery-slots.yml
 data/cache/*
 data/jobstate/*

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ without the burden of needing to physically do so).
 It has been written to make this check at approximately 10-minute intervals by default, in order to prevent unnecessary spikes in
 traffic to the Asda site.
 
-Also, for each postcode this process will only be performed each day until at least one available delivery slot has been
-retrieved for the first time. Once an SMS has been sent to all recipients, this task is bypassed for the rest of the
-current day, and will resume again after midnight.
+Also, for each postcode this process will be performed each day until at least one available delivery slot has been
+retrieved for the first time. Once an SMS has been sent to all recipients, this task is bypassed for a set duration
+of time (default is 2 hours), and will resume again after this point.
 
 The interval setting can be changed in the code prior to execution.
 

--- a/README.md
+++ b/README.md
@@ -39,19 +39,19 @@ Otherwise, if you are setting it up for your own use...
 Running this program is effectively no different to periodically refreshing the Asda website manually (but
 without the burden of needing to physically do so).
 
-It has been written to make this check every 10 minutes by default, in order to prevent unnecessary spikes in
+It has been written to make this check at approximately 10-minute intervals by default, in order to prevent unnecessary spikes in
 traffic to the Asda site.
 
-Also, this process will only be performed each day until at least one available delivery slot has been retrieved for the
-first time. Once an SMS has been sent to all recipients, this task is bypassed for the rest of the current day, and
-will resume again after midnight.
+Also, for each postcode this process will only be performed each day until at least one available delivery slot has been
+retrieved for the first time. Once an SMS has been sent to all recipients, this task is bypassed for the rest of the
+current day, and will resume again after midnight.
 
 The interval setting can be changed in the code prior to execution.
 
 **HOWEVER... if you are inclined to amend this, please be a good citizen and consider the implications this will
 have.**
 
-(i.e. Don't do anything silly and get your IP blocked... :-)
+(i.e. don't do anything silly and get your IP blocked... 🙂)
 
 ## Installation
 
@@ -63,8 +63,8 @@ cp .env.example .env
 
 * Next, make sure you have signed up for an account at [Nexmo](https://dashboard.nexmo.com/)
 
-* You'll need to obtain your *API Key* and *API Secret*, which you can find in the
-[Getting Started Guide](https://dashboard.nexmo.com/getting-started-guide), underneath the heading _Your API credentials_.
+* You'll need to obtain your _API Key_ and _API Secret_, which you can find in the
+[Getting Started Guide](https://dashboard.nexmo.com/getting-started-guide), underneath the heading **Your API credentials**.
 Add these credentials to your new `.env` file as `NEXMO_KEY` and `NEXMO_SECRET` respectively.
 
 ```
@@ -72,25 +72,28 @@ NEXMO_KEY=my_key_from_nexmo
 NEXMO_SECRET=my_secret_from_nexmo
 ```
 
-*Please note:* there is a monetary cost attached to each SMS that is issued via Nexmo. As at April 2020, this is approximately
-0.03-0.04EUR per message.
+_Please note:_ There is a monetary cost attached to each SMS that is issued via Nexmo. As at April 2020, this is approximately
+**0.03-0.04EUR** per message. Please refer to Nexmo's [pricing guide](https://www.vonage.com/communications-apis/sms/pricing/)
+for exact costs.
 
-* Now you will need to create a task data file, which you can do by copying the example provided:
+* Now you will need to create your task payloads data file, which you can do by copying the example provided:
 
 ```bash
-cp data/tasks/asda-check-delivery-slots.example.yml data/tasks/asda-check-delivery-slots.yml
+cp data/tasks/payloads.example.yml data/tasks/payloads.yml
 ```
 
-* In this file, you can set the postcode to be searched for delivery slots, as well as the recipients who should receive
-an alert for this postcode:
+* In this file, you can configure the postcodes you'd like to find delivery slots for, as well as the recipients who should
+receive an alert when available delivery slots are found for each postcode:
 
-```
+```yaml
 -
-  postcode: AB120AB
+  identifier: ab12-0ab   # log prefix
+  interval: 600          # number of seconds between each execution
+  postcode: AB120AB      # postcode to search
   recipients:
     -
-      name: Mick      # recipient's name
-      mobile: +44XXX  # recipient's mobile number
+      name: Mick         # recipient's name
+      mobile: +44XXX     # recipient's mobile number
     -
       name: Keith
       mobile: +44XXX
@@ -100,9 +103,27 @@ an alert for this postcode:
     -
       name: Charlie
       mobile: +44XXX
+-
+  identifier: ba21-9ba
+  interval: 600
+  postcode: BA219BA
+  recipients:
+    -
+      name: Johnny
+      mobile: +44XXX
+    -
+      name: Joey
+      mobile: +44XXX
+    -
+      name: Dee Dee
+      mobile: +44XXX
+    -
+      name: Tommy
+      mobile: +44XXX
+
 ```
 
-If you need more postcodes, you can copy this whole data structure and repeat it underneath (as long the file remains valid YAML).
+If you need more postcodes, you can keep copying this data structure and repeat it underneath (as long the file remains valid YAML).
 
 ## Usage
 

--- a/data/task/payloads.example.yml
+++ b/data/task/payloads.example.yml
@@ -1,7 +1,7 @@
 -
-  identifier: ab12-0ab
-  interval: 600
-  postcode: AB120AB
+  identifier: ab12-0ab   # log prefix
+  interval: 600          # number of seconds between each execution
+  postcode: AB120AB      # postcode to search
   recipients:
     -
       name: Mick      # recipient's name

--- a/data/task/payloads.example.yml
+++ b/data/task/payloads.example.yml
@@ -1,4 +1,6 @@
 -
+  identifier: ab12-0ab
+  interval: 600
   postcode: AB120AB
   recipients:
     -
@@ -14,6 +16,8 @@
       name: Charlie
       mobile: +44XXX
 -
+  identifier: ba21-9ba
+  interval: 600
   postcode: BA219BA
   recipients:
     -

--- a/data/task/payloads.example.yml
+++ b/data/task/payloads.example.yml
@@ -1,0 +1,30 @@
+-
+  postcode: AB120AB
+  recipients:
+    -
+      name: Mick      # recipient's name
+      mobile: +44XXX  # recipient's mobile number
+    -
+      name: Keith
+      mobile: +44XXX
+    -
+      name: Ronnie
+      mobile: +44XXX
+    -
+      name: Charlie
+      mobile: +44XXX
+-
+  postcode: BA219BA
+  recipients:
+    -
+      name: Johnny
+      mobile: +44XXX
+    -
+      name: Joey
+      mobile: +44XXX
+    -
+      name: Dee Dee
+      mobile: +44XXX
+    -
+      name: Tommy
+      mobile: +44XXX

--- a/data/tasks/asda-check-delivery-slots.example.yml
+++ b/data/tasks/asda-check-delivery-slots.example.yml
@@ -1,9 +1,0 @@
--
-  postcode: AB120AB
-  recipients:
-    -
-      name: John Doe    # recipient's name
-      mobile: +44XXX    # recipient's mobile number
-    -
-      name: Jane Doe    # recipient's name
-      mobile: +44XXX    # recipient's mobile number

--- a/domain/merchant/asda.go
+++ b/domain/merchant/asda.go
@@ -15,10 +15,11 @@ const (
 	asdaStatusUnavailable = "UNAVAILABLE"
 )
 
+var asdaURL = "https://groceries.asda.com/api/v3"
+
 // AsdaClient defines a client for interacting with the Asda supermarket.
 type AsdaClient struct {
 	Client
-	URL string
 }
 
 // GetName returns the supermarket name.
@@ -36,7 +37,7 @@ func (c AsdaClient) GetDeliverySlots(postcode string, from, to time.Time) ([]Del
 	}
 
 	httpResponse, err := http.Post(
-		fmt.Sprintf("%s/slot/view", c.URL),
+		fmt.Sprintf("%s/slot/view", asdaURL),
 		"application/json",
 		bytes.NewReader(httpRequestBody),
 	)

--- a/domain/merchant/merchant.go
+++ b/domain/merchant/merchant.go
@@ -153,10 +153,3 @@ type Client interface {
 	GetName() string
 	GetDeliverySlots(locationID string, from, to time.Time) ([]DeliverySlot, error)
 }
-
-// NewClient instantiates the default Client
-func NewClient() Client {
-	return AsdaClient{
-		URL: "https://groceries.asda.com/api/v3",
-	}
-}

--- a/domain/merchant/merchant.go
+++ b/domain/merchant/merchant.go
@@ -91,7 +91,7 @@ func (m *DeliveryManifest) FilterByAvailability(isAvailable bool) {
 		MerchantName:   m.MerchantName,
 		From:           m.From,
 		Until:          m.Until,
-		DailySchedules: nil,
+		DailySchedules: []DailySchedule,
 		Created:        m.Created,
 	}
 
@@ -106,7 +106,9 @@ func (m *DeliveryManifest) FilterByAvailability(isAvailable bool) {
 			}
 		}
 
-		filteredManifest.DailySchedules = append(filteredManifest.DailySchedules, filteredSchedule)
+		if len(filteredSchedule.Slots) > 0 {
+			filteredManifest.DailySchedules = append(filteredManifest.DailySchedules, filteredSchedule)
+		}
 	}
 
 	*m = filteredManifest

--- a/domain/merchant/merchant.go
+++ b/domain/merchant/merchant.go
@@ -112,6 +112,7 @@ func (m *DeliveryManifest) FilterByAvailability(isAvailable bool) {
 	*m = filteredManifest
 }
 
+// NewDeliveryManifest populates a new DeliveryManifest from the provided merchantName and DeliverySlots
 func NewDeliveryManifest(merchantName string, slots []DeliverySlot) (DeliveryManifest, error) {
 	scheduleMap := make(map[string]DailySchedule)
 

--- a/domain/work/asda.go
+++ b/domain/work/asda.go
@@ -11,10 +11,7 @@ import (
 )
 
 var AsdaDeliverySlotsTask = Task(func(payload TaskPayload, state *TaskState, w WriterWithIdentifier) error {
-	asdaClient := merchant.AsdaClient{
-		URL: "https://groceries.asda.com/api/v3",
-	}
-	return checkForDeliverySlots(asdaClient, payload, state, w)
+	return checkForDeliverySlots(merchant.AsdaClient{}, payload, state, w)
 })
 
 func checkForDeliverySlots(client merchant.Client, payload TaskPayload, state *TaskState, w WriterWithIdentifier) error {

--- a/domain/work/asda.go
+++ b/domain/work/asda.go
@@ -21,7 +21,7 @@ func checkForDeliverySlots(client merchant.Client, payload TaskPayload, state *T
 	state.LatestRun = time.Now()
 
 	if state.Bypass {
-		return errors.New("bypassing task")
+		return errors.New("bypassing task...")
 	}
 
 	now := time.Now()

--- a/domain/work/asda.go
+++ b/domain/work/asda.go
@@ -15,13 +15,9 @@ var AsdaDeliverySlotsTask = Task(func(payload TaskPayload, state *TaskState, w W
 })
 
 func checkForDeliverySlots(client merchant.Client, payload TaskPayload, state *TaskState, w WriterWithIdentifier) error {
-	state.LatestRun = time.Now()
-
-	if state.Bypass {
-		return errors.New("bypassing task...")
-	}
-
 	now := time.Now()
+	state.LatestRun = now
+
 	loc, err := time.LoadLocation("Europe/London")
 	if err != nil {
 		return apperrors.FatalError{Err: err}
@@ -71,7 +67,7 @@ func checkForDeliverySlots(client merchant.Client, payload TaskPayload, state *T
 		}
 	}
 
-	state.Bypass = true
+	state.BypassUntil = now.Add(bypassDuration * time.Second)
 
 	return nil
 }

--- a/domain/work/asda.go
+++ b/domain/work/asda.go
@@ -24,10 +24,10 @@ func checkForDeliverySlots(client merchant.Client, payload TaskPayload, state *T
 	}
 
 	todayAtMidnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
-	tsInSevenDays := todayAtMidnight.Add(7 * 24 * time.Hour)
+	tsTomorrow := todayAtMidnight.Add(24 * time.Hour)
 	tsInTwentyOneDays := todayAtMidnight.Add(22 * 24 * time.Hour).Add(-time.Second)
 
-	slots, err := client.GetDeliverySlots(payload.Postcode, tsInSevenDays, tsInTwentyOneDays)
+	slots, err := client.GetDeliverySlots(payload.Postcode, tsTomorrow, tsInTwentyOneDays)
 	if err != nil {
 		return err
 	}

--- a/domain/work/asda.go
+++ b/domain/work/asda.go
@@ -67,7 +67,7 @@ func checkForDeliverySlots(client merchant.Client, payload TaskPayload, state *T
 		}
 	}
 
-	state.BypassUntil = now.Add(bypassDuration * time.Second)
+	state.BypassUntil = now.Add(getDefaultBypassDuration())
 
 	return nil
 }

--- a/domain/work/jobs.go
+++ b/domain/work/jobs.go
@@ -26,6 +26,15 @@ func (w WriterWithIdentifier) Write(p []byte) (int, error) {
 	return w.Writer.Write([]byte(value))
 }
 
+// TaskPayload represents the data structure that will be passed to, and acted on by, a Task
+type TaskPayload struct {
+	Postcode   string `yaml:"postcode"`
+	Recipients []struct {
+		Name   string `yaml:"name"`
+		Mobile string `yaml:"mobile"`
+	} `yaml:"recipients"`
+}
+
 // Task represents the function executed by a Job
 type Task func(state *JobState, w WriterWithIdentifier) error
 
@@ -33,6 +42,7 @@ type Task func(state *JobState, w WriterWithIdentifier) error
 type Job struct {
 	Name     string
 	Task     Task
+	Payloads []TaskPayload
 	Interval time.Duration
 }
 

--- a/domain/work/jobs.go
+++ b/domain/work/jobs.go
@@ -18,7 +18,7 @@ const minInterval = 600
 // somewhere between 593 and 607 seconds
 const offset = 7
 
-// bypassDuration represents a default duration in seconds for which bypassed tasks should be ignored by the runner
+// bypassDuration represents a default duration in minutes for which bypassed tasks should be ignored by the runner
 const bypassDuration = 120
 
 // WriterWithIdentifier represents a writer with a log-style prefix that appears after a timestamp
@@ -150,4 +150,8 @@ func getRandomisedInterval(interval time.Duration) time.Duration {
 	randomInterval := r.Intn(int(upperLimit)-int(lowerLimit)-1) + int(lowerLimit)
 
 	return time.Duration(randomInterval)
+}
+
+func getDefaultBypassDuration() time.Duration {
+	return bypassDuration * time.Minute
 }

--- a/domain/work/jobs.go
+++ b/domain/work/jobs.go
@@ -61,7 +61,7 @@ type Runner struct {
 
 // runTask enables the concurrent execution of a Task
 func runTask(task Task, payload TaskPayload, w WriterWithIdentifier, ch chan Task) {
-	stateName := fmt.Sprintf("%s_%s", payload.Identifier, time.Now().Format("20060102"))
+	stateName := fmt.Sprintf("%s_%s", time.Now().Format("20060102"), payload.Identifier)
 
 	state, err := LoadStateCreateIfMissing(stateName)
 	if err != nil {
@@ -136,7 +136,7 @@ func getRandomisedInterval(interval time.Duration) time.Duration {
 	upperLimit = base + offset
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	randomInterval := r.Intn((int(upperLimit) - int(lowerLimit) - 1) + int(lowerLimit))
+	randomInterval := r.Intn(int(upperLimit)-int(lowerLimit)-1) + int(lowerLimit)
 
 	return time.Duration(randomInterval)
 }

--- a/domain/work/jobs.go
+++ b/domain/work/jobs.go
@@ -115,7 +115,7 @@ func (r Runner) Run() {
 	}
 
 	// block indefinitely to allow runTask() goroutines to run within per-payload goroutines
-	// if any of the tasks return an apperrors.FatalError, current program will exit
+	// if any of the task runs return an apperrors.FatalError, current program will exit
 	func() { select {} }()
 }
 

--- a/domain/work/state.go
+++ b/domain/work/state.go
@@ -8,34 +8,33 @@ import (
 	"time"
 )
 
-const stateDir = "./data/jobstate"
+const stateDir = "./data/taskstate"
 
-// JobState represents the latest state of our job
-type JobState struct {
+// TaskState represents the latest state of our job
+type TaskState struct {
 	Bypass    bool      `json:"bypass"`
-	Status    string    `json:"status"`
 	LatestRun time.Time `json:"latest_run"`
 	FirstRun  time.Time `json:"first_run"`
 }
 
-// LoadState reads job state from disk
-func LoadState(name string) (JobState, error) {
+// LoadState reads task state from disk
+func LoadState(name string) (TaskState, error) {
 	contents, err := ioutil.ReadFile(getFullPathToStateFile(name))
 	if err != nil {
-		return JobState{}, err
+		return TaskState{}, err
 	}
 
-	var jobState JobState
+	var jobState TaskState
 	err = json.Unmarshal(contents, &jobState)
 	if err != nil {
-		return JobState{}, err
+		return TaskState{}, err
 	}
 
 	return jobState, err
 }
 
-// SaveState stores job state on disk
-func SaveState(name string, state JobState) error {
+// SaveState stores task state on disk
+func SaveState(name string, state TaskState) error {
 	err := os.MkdirAll(stateDir, 0755)
 	if err != nil {
 		return err
@@ -50,17 +49,17 @@ func SaveState(name string, state JobState) error {
 }
 
 // LoadStateCreateIfMissing will attempt to load state from disk, or create if not existing
-func LoadStateCreateIfMissing(name string) (JobState, error) {
+func LoadStateCreateIfMissing(name string) (TaskState, error) {
 	state, err := LoadState(name)
 
 	if err != nil {
 		// save initial state
-		state = JobState{
+		state = TaskState{
 			FirstRun:  time.Now(),
 			LatestRun: time.Now(),
 		}
 		if err := SaveState(name, state); err != nil {
-			return JobState{}, err
+			return TaskState{}, err
 		}
 	}
 

--- a/domain/work/state.go
+++ b/domain/work/state.go
@@ -10,7 +10,7 @@ import (
 
 const stateDir = "./data/taskstate"
 
-// TaskState represents the latest state of our job
+// TaskState represents the latest state of our task
 type TaskState struct {
 	Bypass    bool      `json:"bypass"`
 	LatestRun time.Time `json:"latest_run"`
@@ -24,13 +24,13 @@ func LoadState(name string) (TaskState, error) {
 		return TaskState{}, err
 	}
 
-	var jobState TaskState
-	err = json.Unmarshal(contents, &jobState)
+	var taskState TaskState
+	err = json.Unmarshal(contents, &taskState)
 	if err != nil {
 		return TaskState{}, err
 	}
 
-	return jobState, err
+	return taskState, err
 }
 
 // SaveState stores task state on disk

--- a/domain/work/state.go
+++ b/domain/work/state.go
@@ -12,9 +12,9 @@ const stateDir = "./data/taskstate"
 
 // TaskState represents the latest state of our task
 type TaskState struct {
-	Bypass    bool      `json:"bypass"`
-	LatestRun time.Time `json:"latest_run"`
-	FirstRun  time.Time `json:"first_run"`
+	BypassUntil time.Time `json:"bypass_until"`
+	LatestRun   time.Time `json:"latest_run"`
+	FirstRun    time.Time `json:"first_run"`
 }
 
 // LoadState reads task state from disk

--- a/main.go
+++ b/main.go
@@ -3,8 +3,11 @@ package main
 import (
 	"delivery-slot-checker/domain/work"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/joho/godotenv"
 )
@@ -26,9 +29,21 @@ func main() {
 		}
 	}
 
+	// retrieve and parse task payloads
+	var taskPayloads []work.TaskPayload
+	taskPayloadsFileContents, err := ioutil.ReadFile("./data/task/payloads.yml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = yaml.Unmarshal(taskPayloadsFileContents, &taskPayloads)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	asdaCheckDeliverySlotsJob := work.Job{
 		Name:     "asda-check-delivery-slots-job",
 		Task:     work.AsdaCheckDeliverySlotsTask,
+		Payloads: taskPayloads,
 		Interval: 600,
 	}
 

--- a/main.go
+++ b/main.go
@@ -40,17 +40,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	asdaCheckDeliverySlotsJob := work.Job{
-		Name:     "asda-check-delivery-slots-job",
-		Task:     work.AsdaCheckDeliverySlotsTask,
-		Payloads: taskPayloads,
-		Interval: 600,
+	// configure Asda job
+	asdaDeliverySlotsJob := work.Job{
+		Identifier: "asda-delivery-slots",
+		Task:       work.AsdaDeliverySlotsTask,
+		Payloads:   taskPayloads,
 	}
 
 	runner := work.Runner{
 		Writer: os.Stdout,
 		Jobs: []work.Job{
-			asdaCheckDeliverySlotsJob,
+			asdaDeliverySlotsJob,
 		},
 	}
 


### PR DESCRIPTION
The purpose of this change is to shift the focus from Jobs to Tasks in terms of maintaining state, configuration, execution and monitoring.

This enables multiple Task Payloads to be associated with a single Job. The Job's Task function can then be run multiple times, taking in a different Payload each time.

Each Payload now becomes the single unit that we wish to maintain state for independently, rather than the Job.

Each Task-Payload combination can now be executed concurrently, in parallel to the other Task-Payload combinations within the same Job, as well as any other Jobs.

Other changes include:
- Make delay/interval between Task runs configurable on a per-Task basis. Also randomise this slightly, between an upper/lower bound that is determined by a numeric global offset either side of the task interval (e.g. +/- 7 seconds).
- Configure Task bypass as a timestamp rather than a boolean. This enables a Task to be bypassed for a specific duration of time, rather than indefinitely until a new Task State file takes over (i.e. the next day)